### PR TITLE
[musl] fix build

### DIFF
--- a/src/BWidgets/FileChooser.cpp
+++ b/src/BWidgets/FileChooser.cpp
@@ -17,6 +17,7 @@
 
 #include "FileChooser.hpp"
 #include <dirent.h>
+#include <limits.h>
 #include <sys/stat.h>
 
 namespace BWidgets


### PR DESCRIPTION
Need to include limits.h else

```
Build BOops.lv2 GUI...../../src/BWidgets/FileChooser.cpp: In member function 'void BWidgets::FileChooser::setPath(const string&)':
../../src/BWidgets/FileChooser.cpp:225:12: error: 'PATH_MAX' was not declared in this scope
  225 |   char buf[PATH_MAX];
      |            ^~~~~~~~
../../src/BWidgets/FileChooser.cpp:226:37: error: 'buf' was not declared in this scope
  226 |   char *rp = realpath(path.c_str(), buf);
      |                                     ^~~
../../src/BWidgets/FileChooser.cpp: In static member function 'static void BWidgets::FileChooser::okButtonClickedCallback(BEvents::Event*)':
../../src/BWidgets/FileChooser.cpp:610:16: error: 'PATH_MAX' was not declared in this scope
  610 |       char buf[PATH_MAX];
      |                ^~~~~~~~
../../src/BWidgets/FileChooser.cpp:611:48: error: 'buf' was not declared in this scope
  611 |           char *rp = realpath(newPath.c_str(), buf);
      |                                                ^~~
make: *** [makefile:138: BOopsGUI.so] Error 1
```

tested x86_64-musl